### PR TITLE
change all Prometheus metrics units to bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The Teraslice Job Setting Controller(TJSC) is designed to continuously modify the `percent` field of an Elasticsearch record. This record is used within a [Teraslice](https://github.com/terascope/teraslice) job by the [sample_exact_es_percent](https://github.com/terascope/standard-assets/blob/master/docs/asset/operations/sample_exact_es_percent.md) operation to configure the percentage of records to keep. The TJSC monitors the size of an Elasticsearch index in the downstream pipeline of this operation. Every `window_ms` it compares its rate of growth with a `target_rate` of growth. It then feeds the error in the rate of growth to a PID Controller, which calculates an adjustment to the percentage of records to keep.
 
+## Configuration
+
 | Configuration | Description | Type |  Notes |
 | ------------- | ----------- | ---- | ------ |
 | 'target_rate' | 'The target rate of index growth in MB/sec' | number | required |
@@ -19,3 +21,12 @@ The Teraslice Job Setting Controller(TJSC) is designed to continuously modify th
 | connections.sample.daily_index_prefix | 'prefix of the daily index to sample. This will match the index field of the elasticsearch_sender_api config in the teraslice job writing to the index.' | String | required |
 | connections.sample.date_delimiter |  'delimiter between date fields for the daily index. This will match the date_delimiter field of the date_router config in the teraslice job writing to the index.' | String | defaults to '.' |
 
+## How to calculate target_rate
+
+Let's say you want a daily index of 100GB. To convert GB/day to MB/sec you would need to do the following:  
+  
+100GB/day x (1024MB/1GB) x (1day/24hr) x (1hr/60min) x (1min/60sec)  
+= 100 x (1024/86400)  
+= 100 x 0.01185185 = 1.185MB/sec
+
+So multiply daily index size in GB by 0.01185185 to get the MB/sec

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
+    "setup": "yarn && yarn run build --force",
     "start": "node service.js"
   },
   "dependencies": {


### PR DESCRIPTION
This PR makes the following changes:
- change prometheus metrics units to bytes
- add yarn setup script
- add to README

ref: #3 