### PR TITLE
Fix Docker image name for GitHub Container Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: tjsc
+  IMAGE_NAME: terascope/tjsc
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## Summary
- Fixes the Docker image name in the GitHub Actions workflow
- Changes from `tjsc` to `terascope/tjsc` to include the organization name
- This is required for GitHub Container Registry (ghcr.io) which expects the format `ghcr.io/OWNER/NAME`

## Test plan
- [ ] Create a new release to verify the workflow runs successfully with the corrected image name
- [ ] Verify image is pushed to ghcr.io/terascope/tjsc with correct tags

🤖 Generated with [Claude Code](https://claude.ai/code)