### PR TITLE
Add Helm chart publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image on Release
+name: Build and Push Docker Image and Helm Chart on Release
 
 on:
   release:
@@ -7,6 +7,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: terascope/tjsc
+  CHART_NAME: terascope/tjsc-chart
 
 jobs:
   build-and-push:
@@ -42,3 +43,30 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'latest'
+
+      - name: Update Helm chart version
+        run: |
+          # Extract version from release tag (remove 'v' prefix if present)
+          VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=${VERSION#v}
+          
+          # Update Chart.yaml with release version
+          sed -i "s/^version:.*/version: $VERSION/" helm/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" helm/Chart.yaml
+
+      - name: Package and push Helm chart
+        run: |
+          # Extract version from release tag
+          VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=${VERSION#v}
+          
+          # Package the chart
+          helm package helm/
+          
+          # Push to OCI registry
+          helm push teraslice-job-settings-controller-$VERSION.tgz oci://${{ env.REGISTRY }}/${{ env.CHART_NAME }}

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: teraslice-job-settings-controller
 description: Application to monitor the size of an elasticsearch index
 type: application
-version: 0.0.3
-appVersion: "0.0.3"
+version: 0.0.4
+appVersion: "0.0.4"
 keywords:
   - teraslice-job-settings-controller
   - teraslice

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teraslice-job-settings-controller",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "type": "module",
   "description": "Application to monitor the size of an elasticsearch index",
   "main": "service.js",


### PR DESCRIPTION
## Summary
- Extends existing Docker release workflow to also publish Helm chart to OCI registry
- Publishes chart to ghcr.io/terascope/tjsc-chart as OCI artifact
- Updates chart version and appVersion to match release tag automatically
- Bumps package.json and Chart.yaml versions to 0.0.4 for consistency

## Test plan
- [ ] Create a new release to verify both Docker image and Helm chart are published
- [ ] Verify chart is available at ghcr.io/terascope/tjsc-chart
- [ ] Test installation with: `helm install tjsc oci://ghcr.io/terascope/tjsc-chart --version x.y.z`

## Benefits
- Consistent distribution mechanism alongside Docker images
- No need to maintain separate Helm repository
- Easy installation for users
- Version alignment between Docker images and Helm charts

Resolves #11

🤖 Generated with [Claude Code](https://claude.ai/code)